### PR TITLE
Slider widget

### DIFF
--- a/filter-explorer/Piece.js
+++ b/filter-explorer/Piece.js
@@ -87,10 +87,24 @@ class Piece {
     }
 
     /**
+     * Gets the input amplitude.
+     */
+    get inAmp() {
+        return this._inAmp;
+    }
+
+    /**
      * Sets the output amplitude.
      */
     set amp(value) {
         this._amp = value;
+    }
+
+    /**
+     * Gets the output amplitude.
+     */
+    get amp() {
+        return this._amp;
     }
 
     /**
@@ -115,11 +129,25 @@ class Piece {
     }
 
     /**
+     * Gets the filter type.
+     */
+    get filterType() {
+        return this._filterType;
+    }
+
+    /**
      * Sets the center frequency.
      */
     set f0(value) {
         this._f0 = value;
         this._calcFilter();
+    }
+
+    /**
+     * Gets the center frequency.
+     */
+    get f0() {
+        return this._f0;
     }
 
     /**
@@ -132,6 +160,13 @@ class Piece {
 
         this._q = value;
         this._calcFilter();
+    }
+
+    /**
+     * Gets Q (the filter quality).
+     */
+    get q() {
+        return this._q;
     }
 
     /**

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -17,6 +17,9 @@ button {
 #sliderCell {
     width: 500px;
     height: 100px;
+}
+
+.slider {
     background-color: red;
     color: blue;
 }

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -14,19 +14,6 @@ button {
     border-radius: 5pt;
 }
 
-.sliderCell {
-    width: 100%;
-    height: 28pt;
-}
-
-.slider {
-    width: 100%;
-    height: 28pt;
-    background-color: #eeeeee;
-    color: black;
-    font-size: 15pt;
-}
-
 .soundDisplay {
     background-color: black;
     color: #00ff00;
@@ -100,4 +87,17 @@ button {
 
 #controlTable td:first-child + td + td {
     text-align: right;
+}
+
+.sliderCell {
+    width: 100%;
+    height: 28pt;
+}
+
+.slider {
+    width: 100%;
+    height: 28pt;
+    background-color: #eeeeee;
+    color: black;
+    font-size: 15pt;
 }

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -16,7 +16,7 @@ button {
 
 #sliderCell {
     width: 500px;
-    height: 100px;
+    height: 28pt;
 }
 
 .slider {

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -20,7 +20,7 @@ button {
 }
 
 .slider {
-    background-color: #ccffcc;
+    background-color: #eeeeee;
     color: black;
     font-size: 15pt;
 }

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -14,6 +14,13 @@ button {
     border-radius: 5pt;
 }
 
+#sliderCell {
+    width: 500px;
+    height: 100px;
+    background-color: red;
+    color: blue;
+}
+
 .soundDisplay {
     background-color: black;
     color: #00ff00;

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -14,12 +14,14 @@ button {
     border-radius: 5pt;
 }
 
-#sliderCell {
-    width: 500px;
+.sliderCell {
+    width: 100%;
     height: 28pt;
 }
 
 .slider {
+    width: 100%;
+    height: 28pt;
     background-color: #eeeeee;
     color: black;
     font-size: 15pt;
@@ -76,12 +78,8 @@ button {
     width: 100%;
 }
 
-#controlTable tr:nth-child(even) td {
+#controlTable td {
     padding-bottom: 1em;
-}
-
-#controlTable input[type="range"] {
-    width: 100%;
 }
 
 #controlTable input[type="radio"] {

--- a/filter-explorer/index.css
+++ b/filter-explorer/index.css
@@ -20,8 +20,9 @@ button {
 }
 
 .slider {
-    background-color: red;
-    color: blue;
+    background-color: #ccffcc;
+    color: black;
+    font-size: 15pt;
 }
 
 .soundDisplay {

--- a/filter-explorer/index.html
+++ b/filter-explorer/index.html
@@ -80,7 +80,7 @@
         <tr><td/><td id="ampText">0.5</td><td/></tr>
     </table>
 
-    <div id="sliderCell" style="background-color: red; color: blue; width: 500px; height: 100px"></div>
+    <div id="sliderCell"></div>
 
     <h3>What is this?</h3>
 

--- a/filter-explorer/index.html
+++ b/filter-explorer/index.html
@@ -80,6 +80,8 @@
         <tr><td/><td id="ampText">0.5</td><td/></tr>
     </table>
 
+    <div id="sliderCell" style="background-color: red; color: blue; width: 500px; height: 100px"></div>
+
     <h3>What is this?</h3>
 
     <p>This is an audio generator tool to explore the timbral quality imparted

--- a/filter-explorer/index.html
+++ b/filter-explorer/index.html
@@ -45,42 +45,27 @@
                 </input>
             </td>
         </tr>
-        <tr><td></td></tr>
         <tr>
             <td>Low Input Amp</td>
-            <td>
-                <input id="inAmp" type="range" value="1" min="0" max="10" step="0.1">
-            </td>
+            <td id="inAmp" class="sliderCell"></td>
             <td>High Input Amp</td>
         </tr>
-        <tr><td/><td id="inAmpText">1</td><td/></tr>
         <tr>
             <td>Low Center <i>f<sub>0</sub></i></td>
-            <td>
-                <input id="f0" type="range" value="440" min="20" max="8000" step="1">
-            </td>
+            <td id="f0" class="sliderCell"></td>
             <td>High Center <i>f<sub>0</sub></i></td>
         </tr>
-        <tr><td/><td id="f0Text">440</td><td/></tr>
         <tr>
             <td>Low <i>Q</i></td>
-            <td>
-                <input id="q" type="range" value="10" min="0" max="500" step="0.01">
-            </td>
+            <td id="q" class="sliderCell"></td>
             <td>High <i>Q</i></td>
         </tr>
-        <tr><td/><td id="qText">10</td><td/></tr>
         <tr>
             <td>Low Amplitude</td>
-            <td>
-                <input id="amp" type="range" value="0.5" min="0" max="10" step="0.1">
-            </td>
+            <td id="amp" class="sliderCell"></td>
             <td>High Amplitude</td>
         </tr>
-        <tr><td/><td id="ampText">0.5</td><td/></tr>
     </table>
-
-    <div id="sliderCell"></div>
 
     <h3>What is this?</h3>
 

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -64,4 +64,6 @@ for (var i = 0; i < filterRadios.length; i++) {
     };
 }
 
+var slider = new SliderWidget(document.querySelector("#sliderCell"));
+
 });

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -13,8 +13,9 @@
 });
 
 requirejs(
-["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope"],
-function(Piece, Harmonics, MusicControl, Oscilloscope) {
+["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope",
+    "lib/SliderWidget"],
+function(Piece, Harmonics, MusicControl, Oscilloscope, SliderWidget) {
 
 // The overall audio context instance. Unfortunately, the name
 // `AudioContext` isn't fully standardized and is prefixed in some

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -66,5 +66,6 @@ for (var i = 0; i < filterRadios.length; i++) {
 }
 
 var slider = new SliderWidget(document.querySelector("#sliderCell"));
+slider.label = "Slide!";
 
 });

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -65,13 +65,14 @@ for (var i = 0; i < filterRadios.length; i++) {
     };
 }
 
-var slider = new SliderWidget(document.querySelector("#sliderCell"));
-slider.label = "Slide!";
-slider.minValue = 20;
-slider.maxValue = 8000;
-slider.increment = 1;
-slider.precision = 0;
-slider.target = gen;
-slider.targetProperty = "f0";
+var slider = new SliderWidget(document.querySelector("#sliderCell"), {
+    label:          "Slide!",
+    minValue:       20,
+    maxValue:       8000,
+    increment:      1,
+    precision:      0,
+    target:         gen,
+    targetProperty: "f0"
+});
 
 });

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -28,10 +28,6 @@ var mc = new MusicControl(audioCtx, gen);
 mc.oscilloscope = new Oscilloscope(document.querySelector("#oscCell"));
 mc.harmonics = new Harmonics(document.querySelector("#harmCell"));
 
-var f0Text = document.querySelector("#f0Text");
-var qText = document.querySelector("#qText");
-var ampText = document.querySelector("#ampText");
-
 document.querySelector("#playPause").onclick = function() {
     mc.playPause();
 };

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -67,5 +67,11 @@ for (var i = 0; i < filterRadios.length; i++) {
 
 var slider = new SliderWidget(document.querySelector("#sliderCell"));
 slider.label = "Slide!";
+slider.minValue = 20;
+slider.maxValue = 8000;
+slider.increment = 1;
+slider.precision = 0;
+slider.target = gen;
+slider.targetProperty = "f0";
 
 });

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -37,7 +37,6 @@ document.querySelector("#playPause").onclick = function() {
 };
 
 new SliderWidget(document.querySelector("#inAmp"), {
-    label:          "Input Amp",
     minValue:       0,
     maxValue:       10,
     increment:      0.1,
@@ -47,7 +46,6 @@ new SliderWidget(document.querySelector("#inAmp"), {
 });
 
 new SliderWidget(document.querySelector("#f0"), {
-    label:          "f0",
     minValue:       20,
     maxValue:       8000,
     increment:      1,
@@ -57,7 +55,6 @@ new SliderWidget(document.querySelector("#f0"), {
 });
 
 new SliderWidget(document.querySelector("#q"), {
-    label:          "Q",
     minValue:       0,
     maxValue:       500,
     increment:      0.01,
@@ -67,7 +64,6 @@ new SliderWidget(document.querySelector("#q"), {
 });
 
 new SliderWidget(document.querySelector("#amp"), {
-    label:          "Amplitude",
     minValue:       0,
     maxValue:       10,
     increment:      0.1,

--- a/filter-explorer/index.js
+++ b/filter-explorer/index.js
@@ -36,25 +36,45 @@ document.querySelector("#playPause").onclick = function() {
     mc.playPause();
 };
 
-document.querySelector("#inAmp").oninput = function() {
-    gen.inAmp = parseFloat(this.value);
-    inAmpText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#inAmp"), {
+    label:          "Input Amp",
+    minValue:       0,
+    maxValue:       10,
+    increment:      0.1,
+    precision:      1,
+    target:         gen,
+    targetProperty: "inAmp"
+});
 
-document.querySelector("#f0").oninput = function() {
-    gen.f0 = parseFloat(this.value);
-    f0Text.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#f0"), {
+    label:          "f0",
+    minValue:       20,
+    maxValue:       8000,
+    increment:      1,
+    precision:      0,
+    target:         gen,
+    targetProperty: "f0"
+});
 
-document.querySelector("#q").oninput = function() {
-    gen.q = parseFloat(this.value);
-    qText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#q"), {
+    label:          "Q",
+    minValue:       0,
+    maxValue:       500,
+    increment:      0.01,
+    precision:      2,
+    target:         gen,
+    targetProperty: "q"
+});
 
-document.querySelector("#amp").oninput = function() {
-    gen.amp = parseFloat(this.value);
-    ampText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#amp"), {
+    label:          "Amplitude",
+    minValue:       0,
+    maxValue:       10,
+    increment:      0.1,
+    precision:      1,
+    target:         gen,
+    targetProperty: "amp"
+});
 
 var filterRadios =
     document.querySelectorAll("input[name='filterType']");
@@ -64,15 +84,5 @@ for (var i = 0; i < filterRadios.length; i++) {
         gen.filterType = this.value;
     };
 }
-
-var slider = new SliderWidget(document.querySelector("#sliderCell"), {
-    label:          "Slide!",
-    minValue:       20,
-    maxValue:       8000,
-    increment:      1,
-    precision:      0,
-    target:         gen,
-    targetProperty: "f0"
-});
 
 });

--- a/lib/CanvasWidget.js
+++ b/lib/CanvasWidget.js
@@ -40,16 +40,18 @@ class CanvasWidget {
         // Make a `div` to hold the two canvases. It has to be set for
         // explicit relative positioning, otherwise the child nodes "leak"
         // out.
-        var div = doc.createElement("div");
-        div.className = cssClass;
-        style = div.style;
+        this._divNode = doc.createElement("div");
+        style = this._divNode.style;
         style.position = "relative";
         style.width = "100%";
         style.height = "100%";
-        node.appendChild(div);
+        node.appendChild(this._divNode);
 
         /** The node which is consulted for CSS style info. */
-        this._styleNode = div;
+        this._styleNode = doc.createElement("span");
+        this._styleNode.className = cssClass;
+        this._styleNode.display = "hidden";
+        this._divNode.appendChild(this._styleNode);
 
         /** The fixed background canvas. */
         this._background = doc.createElement("canvas");
@@ -75,8 +77,8 @@ class CanvasWidget {
         this._adjustCanvasSizes();
         this._autoAdjustCanvasSizes();
         this._autoRefreshBackground();
-        div.appendChild(this.background);
-        div.appendChild(this.foreground);
+        this._divNode.appendChild(this.background);
+        this._divNode.appendChild(this.foreground);
     }
 
     /**
@@ -125,7 +127,7 @@ class CanvasWidget {
         // Copy the dimensions of the canvas from the `div`, which ensures the
         // aspect ratio remains the same. Thus, the canvases will have square
         // pixels.
-        var node = this._styleNode;
+        var node = this._divNode;
         var fg = this._foreground;
         var bg = this._background;
         var width = node.clientWidth;
@@ -145,7 +147,7 @@ class CanvasWidget {
      * Gets the "default view" (typically the window of the document).
      */
     get defaultView() {
-        return this._styleNode.ownerDocument.defaultView;
+        return this._divNode.ownerDocument.defaultView;
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -8,10 +8,10 @@
 
 define(["./CanvasWidget", "./Color"], function(CanvasWidget, Color) {
 
-/** Fraction of width to use for the handle. */
-var HANDLE_WIDTH_AMT = 0.025;
+/** Fraction of font size to use for the handle width. */
+var HANDLE_WIDTH_AMT = 0.8;
 
-/** Fraction of heightto use for the handle. */
+/** Fraction of height to use for the handle. */
 var HANDLE_HEIGHT_AMT = 0.95;
 
 
@@ -327,7 +327,7 @@ class SliderWidget extends CanvasWidget {
 
     /** The width of the slider handle. */
     get _handleWidth() {
-        return this._foreground.width * HANDLE_WIDTH_AMT;
+        return this.fontSize * HANDLE_WIDTH_AMT;
     }
 
     /** The element-relative x value corresponding to `minValue`. */

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015 the Mimu Authors (Dan Bornstein et alia).
+ * Licensed AS IS and WITHOUT WARRANTY under the Apache License,
+ * Version 2.0. Details: <http://www.apache.org/licenses/LICENSE-2.0>
+ */
+
+"use strict";
+
+/** Label font size as a fraction of canvas height. */
+var LABEL_HEIGHT_AMT = 0.5;
+
+/** Fraction of width to use for the label. */
+var LABEL_WIDTH_AMT = 0.25;
+
+/** Fraction of width to use for the slider. */
+var SLIDER_WIDTH_AMT = 0.75;
+
+/** Fraction of width to use for the handle. */
+var HANDLE_WIDTH_AMT = 0.01;
+
+/** Fraction of heightto use for the handle. */
+var HANDLE_HEIGHT_AMT = 0.9;
+
+
+/**
+ * Slider control widget, with settable label, range, increment, and targeting.
+ */
+class SliderWidget extends CanvasWidget {
+    /**
+     * Takes a DOM node to insert the widget into. The node should be an empty
+     * container.
+     */
+    constructor(node) {
+        super(node, "slider");
+
+        /** Label. */
+        this._label = "";
+
+        /** Minimum value. */
+        this._minValue = 0;
+
+        /** Maximum value. */
+        this._maxValue = 10;
+
+        /** Value increment. */
+        this._increment = 1;
+
+        /** Current value. */
+        this._value = 0;
+
+        this.renderBackground();
+        this.render();
+    }
+
+    /**
+     * Sets the label.
+     */
+    set label(value) {
+        this._label = value;
+        this.renderBackground();
+    }
+
+    /**
+     * Sets the minimum value.
+     */
+    set minValue(value) {
+        this._minValue = value;
+        this.renderBackground();
+        this.value = this.value;  // Clamp if necessary.
+    }
+
+    /**
+     * Sets the maximum value.
+     */
+    set maxValue(value) {
+        this._maxValue = value;
+        this.renderBackground();
+        this.value = this.value;  // Clamp if necessary.
+    }
+
+    /**
+     * Sets the increment.
+     */
+    set increment(value) {
+        this._increment = value;
+        this.renderBackground();
+        this.value = this.value;  // Clamp if necessary.
+    }
+
+    /**
+     * Sets the current value.
+     */
+    set value(value) {
+        value = Math.round(value * this._increment) / this._increment;
+        value = Math.min(value, this._maxValue);
+        value = Math.max(value, this._minValue);
+
+        // Only do anything more if the value has changed.
+        if (value !== this._value) {
+            this._value = value;
+            this.render();
+        }
+    }
+
+    /**
+     * Gets the current value.
+     */
+    get value() {
+        return this._value;
+    }
+
+    /**
+     * Renders the background canvas.
+     */
+    renderBackground() {
+        var canvas = this.background;
+        var style = this.cloneComputedStyle();
+        var ctx = canvas.getContext("2d");
+        var width = canvas.width;
+        var height = canvas.height;
+        var labelWidth = width * LABEL_WIDTH_AMT;
+        var sliderWidth = width * SLIDER_WIDTH_AMT;
+        var handleWidth = width * HANDLE_WIDTH_AMT;
+        var halfHeight = height / 2;
+
+        var backgroundColor = Color.parse(style.backgroundColor).toCss();
+        var foregroundColor = Color.parse(style.color).toCss();
+        console.log("=== " + backgroundColor);
+        console.log("=== " + foregroundColor);
+
+        ctx.fillStyle = backgroundColor;
+        ctx.fillRect(0, 0, width, height);
+
+        var text = this._label + " ";
+        var textWidth = ctx.measureText(text).width;
+        style.fontSize = Math.round(height * LABEL_HEIGHT_AMT) + "px";
+        ctx.fillStyle = foregroundColor;
+        ctx.font = style.font;
+        ctx.textBaseline = "middle";
+        ctx.fillText(text, labelWidth - textWidth, halfHeight);
+
+        ctx.strokeStyle = foregroundColor;
+        ctx.lineWidth = this.thickLineWidth;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.beginPath();
+        ctx.moveTo(labelWidth + (handleWidth/2), halfHeight);
+        ctx.lineTo(labelWidth + sliderWidth - (handleWidth/2), halfHeight);
+        ctx.stroke();
+    }
+
+    /**
+     * Renders the control position into the foreground canvas.
+     */
+    render() {
+        var canvas = this.background;
+        var style = this.cloneComputedStyle();
+        var ctx = canvas.getContext("2d");
+        var width = canvas.width;
+        var height = canvas.height;
+        var labelWidth = width * LABEL_WIDTH_AMT;
+        var sliderWidth = width * SLIDER_WIDTH_AMT;
+        var handleWidth = width * HANDLE_WIDTH_AMT;
+        var handleHeight = height * HANDLE_HEIGHT_AMT;
+        var halfHeight = height / 2;
+
+        var foregroundColor = Color.parse(style.color).toCss();
+
+        ctx.clearRect(0, 0, width, height);
+
+        // Actual "throw" of slider is cut off by half a slider width on either
+        // end.
+        var totalRange = this._maxValue - this._minValue;
+        var totalSlide = sliderWidth - handleWidth;
+        var x = labelWidth + (sliderWidth/2) +
+            ((this._value - this._minValue) / totalRange * totalSlide);
+
+        ctx.fillStyle = foregroundColor;
+        SliderWidget._roundRectPath(ctx,
+            x - (handleWidth/2), halfHeight - (handleHeight/2),
+            handleWidth, handleHeight,
+            handleWidth * 0.25);
+        ctx.fill();
+    }
+
+    /**
+     * Draws a roundrect with given radius. This code was adapted from
+     * the Mozilla "Drawing Shapes" tutorial, at
+     * <https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_shapes>.
+     */
+    static _roundRectPath(ctx, x, y, width, height, radius) {
+        ctx.beginPath();
+        ctx.moveTo(x, y + radius);
+        ctx.lineTo(x, y + height - radius);
+        ctx.quadraticCurveTo(x, y + height, x + radius, y + height);
+        ctx.lineTo(x + width - radius, y + height);
+        ctx.quadraticCurveTo(x + width, y + height,
+            x + width, y + height-radius);
+        ctx.lineTo(x + width, y + radius);
+        ctx.quadraticCurveTo(x + width, y, x + width - radius, y);
+        ctx.lineTo(x + radius, y);
+        ctx.quadraticCurveTo(x, y, x, y + radius);
+    }
+}

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -8,12 +8,6 @@
 
 define(["./CanvasWidget", "./Color"], function(CanvasWidget, Color) {
 
-/** Fraction of width to use for the label. */
-var LABEL_WIDTH_AMT = 0.25;
-
-/** Fraction of width to use for the slider. */
-var SLIDER_WIDTH_AMT = 0.75;
-
 /** Fraction of width to use for the handle. */
 var HANDLE_WIDTH_AMT = 0.025;
 
@@ -22,7 +16,7 @@ var HANDLE_HEIGHT_AMT = 0.95;
 
 
 /**
- * Slider control widget, with settable label, range, increment, and display
+ * Slider control widget, with settable range, increment, and display
  * precision. Use the `target` and `targetProperty` properties to give it an
  * object property to control.
  */
@@ -34,9 +28,6 @@ class SliderWidget extends CanvasWidget {
      */
     constructor(node, props) {
         super(node, "slider");
-
-        /** Label. */
-        this._label = "";
 
         /** Minimum value. */
         this._minValue = 0;
@@ -61,7 +52,7 @@ class SliderWidget extends CanvasWidget {
 
         if (props) {
             var VALID_NAMES = {
-                label: true, minValue: true, maxValue: true, increment: true,
+                minValue: true, maxValue: true, increment: true,
                 precision: true, value: true, target: true, targetProperty: true
             };
             for (var k in props) {
@@ -138,14 +129,6 @@ class SliderWidget extends CanvasWidget {
                 pendingDelta %= 10;
             }
         }
-    }
-
-    /**
-     * Sets the label.
-     */
-    set label(value) {
-        this._label = value;
-        this.renderBackground();
     }
 
     /**
@@ -261,20 +244,11 @@ class SliderWidget extends CanvasWidget {
         var ctx = canvas.getContext("2d");
         var width = canvas.width;
         var height = canvas.height;
-        var labelWidth = this._labelWidth;
         var halfHeight = height / 2;
 
         var foregroundColor = Color.parse(style.color).toCss();
 
         ctx.clearRect(0, 0, width, height);
-
-        ctx.font = style.font;
-        style.fontSize = this.fontSizePx;
-        var text = this._label + " ";
-        var textWidth = ctx.measureText(text).width;
-        ctx.fillStyle = foregroundColor;
-        ctx.textBaseline = "middle";
-        ctx.fillText(text, labelWidth - textWidth, halfHeight);
 
         ctx.strokeStyle = foregroundColor;
         ctx.lineWidth = this.thickLineWidth;
@@ -351,16 +325,6 @@ class SliderWidget extends CanvasWidget {
         ctx.fillText(text, textX, halfHeight);
     }
 
-    /** The width of the left-hand label. */
-    get _labelWidth() {
-        return this._foreground.width * LABEL_WIDTH_AMT;
-    }
-
-    /** The overall width of the slider area (including padding zones). */
-    get _sliderWidth() {
-        return this._foreground.width * SLIDER_WIDTH_AMT;
-    }
-
     /** The width of the slider handle. */
     get _handleWidth() {
         return this._foreground.width * HANDLE_WIDTH_AMT;
@@ -371,15 +335,15 @@ class SliderWidget extends CanvasWidget {
         // Note: The actual "throw" of slider is cut off by half a slider width
         // on either end, plus a little bit extra to account for the thickness
         // of the stroke around the handle.
-        return this._labelWidth + (this._handleWidth / 2) + this.thinLineWidth;
+        return (this._handleWidth / 2) + this.thinLineWidth;
     }
 
     /** The element-relative x value corresponding to `maxValue`. */
     get _xMax() {
         // Note: The actual "throw" of slider is cut off by half a slider width
         // on either end.
-        return this._labelWidth + this._sliderWidth - (this._handleWidth / 2)
-            - this.thinLineWidth;
+        return this._foreground.width
+            - (this._handleWidth / 2) - this.thinLineWidth;
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -150,7 +150,7 @@ class SliderWidget extends CanvasWidget {
     /**
      * Renders the control position into the foreground canvas.
      */
-    render() {
+    renderForeground() {
         var canvas = this.foreground;
         var style = this.cloneComputedStyle();
         var ctx = canvas.getContext("2d");

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -52,6 +52,16 @@ class SliderWidget extends CanvasWidget {
 
         this.renderBackground();
         this.render();
+
+        var outerThis = this;
+        this._divNode.addEventListener("mousedown", function(event) {
+            outerThis.value = outerThis._xToValue(event.offsetX);
+        });
+        this._divNode.addEventListener("mousemove", function(event) {
+            if (event.buttons !== 0) {
+                outerThis.value = outerThis._xToValue(event.offsetX);
+            }
+        });
     }
 
     /**
@@ -90,12 +100,20 @@ class SliderWidget extends CanvasWidget {
     }
 
     /**
-     * Sets the current value.
+     * Clamps and quantizes the given (would-be) value.
      */
-    set value(value) {
+    _clampAndQuantize(value) {
         value = Math.round(value * this._increment) / this._increment;
         value = Math.min(value, this._maxValue);
         value = Math.max(value, this._minValue);
+        return value;
+    }
+
+    /**
+     * Sets the current value.
+     */
+    set value(value) {
+        value = this._clampAndQuantize(value);
 
         // Only do anything more if the value has changed.
         if (value !== this._value) {
@@ -120,9 +138,7 @@ class SliderWidget extends CanvasWidget {
         var ctx = canvas.getContext("2d");
         var width = canvas.width;
         var height = canvas.height;
-        var labelWidth = width * LABEL_WIDTH_AMT;
-        var sliderWidth = width * SLIDER_WIDTH_AMT;
-        var handleWidth = width * HANDLE_WIDTH_AMT;
+        var labelWidth = this._labelWidth;
         var halfHeight = height / 2;
 
         var foregroundColor = Color.parse(style.color).toCss();
@@ -142,8 +158,8 @@ class SliderWidget extends CanvasWidget {
         ctx.lineCap = "round";
         ctx.lineJoin = "round";
         ctx.beginPath();
-        ctx.moveTo(labelWidth + (handleWidth/2), halfHeight);
-        ctx.lineTo(labelWidth + sliderWidth - (handleWidth/2), halfHeight);
+        ctx.moveTo(this._xMin, halfHeight);
+        ctx.lineTo(this._xMax, halfHeight);
         ctx.stroke();
     }
 
@@ -156,9 +172,7 @@ class SliderWidget extends CanvasWidget {
         var ctx = canvas.getContext("2d");
         var width = canvas.width;
         var height = canvas.height;
-        var labelWidth = width * LABEL_WIDTH_AMT;
-        var sliderWidth = width * SLIDER_WIDTH_AMT;
-        var handleWidth = width * HANDLE_WIDTH_AMT;
+        var handleWidth = this._handleWidth;
         var handleHeight = height * HANDLE_HEIGHT_AMT;
         var halfHeight = height / 2;
 
@@ -167,13 +181,7 @@ class SliderWidget extends CanvasWidget {
 
         ctx.clearRect(0, 0, width, height);
 
-        // Actual "throw" of slider is cut off by half a slider width on either
-        // end.
-        var totalRange = this._maxValue - this._minValue;
-        var totalSlide = sliderWidth - handleWidth;
-        var slideRatio = (this._value - this._minValue) / totalRange;
-        var x = labelWidth + (handleWidth / 2) + (slideRatio * totalSlide);
-
+        var x = this._sliderX;
         SliderWidget._roundRectPath(ctx,
             x - (handleWidth / 2), halfHeight - (handleHeight / 2),
             handleWidth, handleHeight,
@@ -192,7 +200,7 @@ class SliderWidget extends CanvasWidget {
         style.fontSize = fontSize + "px";
         var text = " " + this._value + " ";
         var textWidth = ctx.measureText(text).width;
-        var textX = (slideRatio < 0.5)
+        var textX = (x < ((this._xMin + this._xMax) / 2))
             ? (x + handleWidth)
             : (x - handleWidth - textWidth);
         SliderWidget._roundRectPath(ctx,
@@ -210,6 +218,58 @@ class SliderWidget extends CanvasWidget {
         ctx.fillStyle = foregroundColor;
         ctx.textBaseline = "middle";
         ctx.fillText(text, x + handleWidth, halfHeight);
+    }
+
+    /** The width of the left-hand label. */
+    get _labelWidth() {
+        return this._foreground.width * LABEL_WIDTH_AMT;
+    }
+
+    /** The overall width of the slider area (including padding zones). */
+    get _sliderWidth() {
+        return this._foreground.width * SLIDER_WIDTH_AMT;
+    }
+
+    /** The width of the slider handle. */
+    get _handleWidth() {
+        return this._foreground.width * HANDLE_WIDTH_AMT;
+    }
+
+    /** The element-relative x value corresponding to `minValue`. */
+    get _xMin() {
+        // Note: The actual "throw" of slider is cut off by half a slider width
+        // on either end.
+        return this._labelWidth + (this._handleWidth / 2);
+    }
+
+    /** The element-relative x value corresponding to `maxValue`. */
+    get _xMax() {
+        // Note: The actual "throw" of slider is cut off by half a slider width
+        // on either end.
+        return this._labelWidth + this._sliderWidth - (this._handleWidth / 2);
+    }
+
+    /**
+     * The current slider x position as an element-relative x coordinate,
+     * based on the current value.
+     */
+    get _sliderX() {
+        var totalRange = this._maxValue - this._minValue;
+        var totalSlide = this._xMax - this._xMin;
+        var valueRatio = (this._value - this._minValue) / totalRange;
+        return this._xMin + (valueRatio * totalSlide);
+    }
+
+    /**
+     * Given an element-relative x coordinate, return the corresponding
+     * scaled and quantized value.
+     */
+    _xToValue(x) {
+        var totalRange = this._maxValue - this._minValue;
+        var totalSlide = this._xMax - this._xMin;
+        var valueRatio = (x - this._xMin) / totalSlide;
+        var value = this._minValue + (valueRatio * totalRange);
+        return this._clampAndQuantize(value);
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -52,16 +52,44 @@ class SliderWidget extends CanvasWidget {
 
         this.renderBackground();
         this.render();
+        this._inputSetup();
+    }
 
+    /**
+     * Sets up input event handling.
+     */
+    _inputSetup() {
         var outerThis = this;
-        this._divNode.addEventListener("mousedown", function(event) {
+        var target = this._divNode;  // Element that gets all the events.
+        var view = target.ownerDocument.defaultView;  // The window.
+
+        target.addEventListener("mousedown", mousedown);
+
+        // If and when `target.setCapture(true)` (or something like it) becomes
+        // standardly available, then that should be used, at which point the
+        // `mousemove` event could be placed on the `target` instead of `view`,
+        // thereby avoiding all the work to convert `view` coordinates to
+        // `target` coordinates in the event handler.
+
+        function mousedown(event) {
             outerThis.value = outerThis._xToValue(event.offsetX);
-        });
-        this._divNode.addEventListener("mousemove", function(event) {
-            if (event.buttons !== 0) {
-                outerThis.value = outerThis._xToValue(event.offsetX);
-            }
-        });
+
+            view.addEventListener("mousemove", mousemove, true);
+            view.addEventListener("mouseup", mouseup, true);
+        }
+
+        function mouseup(event) {
+            view.removeEventListener("mousemove", mousemove, true);
+            view.removeEventListener("mouseup", mouseup, true);
+        }
+
+        function mousemove(event) {
+            event.stopPropagation();
+            event.preventDefault();
+            var targetCoords = target.getBoundingClientRect();
+            var x = event.clientX - targetCoords.left;
+            outerThis.value = outerThis._xToValue(x);
+        }
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -29,9 +29,10 @@ var HANDLE_HEIGHT_AMT = 0.95;
 class SliderWidget extends CanvasWidget {
     /**
      * Takes a DOM node to insert the widget into. The node should be an empty
-     * container.
+     * container. If given, `props` are taken to be the initial property
+     * bindings.
      */
-    constructor(node) {
+    constructor(node, props) {
         super(node, "slider");
 
         /** Label. */
@@ -58,6 +59,19 @@ class SliderWidget extends CanvasWidget {
         /** Name of the property of the target to control. */
         this._targetProperty = undefined;
 
+        if (props) {
+            var VALID_NAMES = {
+                label: true, minValue: true, maxValue: true, increment: true,
+                precision: true, value: true, target: true, targetProperty: true
+            };
+            for (var k in props) {
+                if (VALID_NAMES[k]) {
+                    this["_" + k] = props[k];
+                }
+            }
+        }
+
+        this._pullValueFromTarget();
         this.renderBackground();
         this.render();
         this._inputSetup();
@@ -114,10 +128,10 @@ class SliderWidget extends CanvasWidget {
                 case WheelEvent.DOM_DELTA_PAGE: { delta *= 100; break; }
             }
 
-            // We only increment by "lines." However, if we're given pixels, we
-            // have to build up a line across a series of events. Thus, we
-            // accumulate into `pendingDelta` and take action when it's over
-            // the line threshold.
+            // We only increment by "lines." However, if we're given in the
+            // event pixels, then we might have to build up a line across a
+            // series of events. Thus, we accumulate into `pendingDelta` and
+            // take action when it's over the line threshold.
             pendingDelta += delta;
             if (Math.abs(pendingDelta) > 10) {
                 outerThis.value += (pendingDelta / 10) * outerThis._increment;

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -105,10 +105,10 @@ class SliderWidget extends CanvasWidget {
             event.stopPropagation();
             event.preventDefault();
 
-            // We treat both up and left as decrement, and down and right as
+            // We treat both down and left as decrement, and up and right as
             // increment. In addition, we scale the delta if given lines or
             // pages.
-            var delta = -(event.deltaX + event.deltaY);
+            var delta = -event.deltaX + event.deltaY;
             switch (event.deltaMode) {
                 case WheelEvent.DOM_DELTA_LINE: { delta *= 10;  break; }
                 case WheelEvent.DOM_DELTA_PAGE: { delta *= 100; break; }
@@ -174,9 +174,7 @@ class SliderWidget extends CanvasWidget {
      */
     set target(t) {
         this._target = t;
-        if (t && this._targetProperty) {
-            this.value = t[this._targetProperty];
-        }
+        this._pullValueFromTarget();
     }
 
     /**
@@ -184,7 +182,19 @@ class SliderWidget extends CanvasWidget {
      */
     set targetProperty(name) {
         this._targetProperty = name;
-        this._target = this._target; // Grab the value if possible.
+        this._pullValueFromTarget();
+    }
+
+    /**
+     * Pulls the value from the target, if available.
+     */
+    _pullValueFromTarget() {
+        if (this._target && this._targetProperty) {
+            var v = this._target[this._targetProperty];
+            if (v !== undefined) {
+                this.value = v;
+            }
+        }
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -127,8 +127,6 @@ class SliderWidget extends CanvasWidget {
 
         var backgroundColor = Color.parse(style.backgroundColor).toCss();
         var foregroundColor = Color.parse(style.color).toCss();
-        console.log("=== " + backgroundColor);
-        console.log("=== " + foregroundColor);
 
         ctx.fillStyle = backgroundColor;
         ctx.fillRect(0, 0, width, height);

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -125,11 +125,9 @@ class SliderWidget extends CanvasWidget {
         var handleWidth = width * HANDLE_WIDTH_AMT;
         var halfHeight = height / 2;
 
-        var backgroundColor = Color.parse(style.backgroundColor).toCss();
         var foregroundColor = Color.parse(style.color).toCss();
 
-        ctx.fillStyle = backgroundColor;
-        ctx.fillRect(0, 0, width, height);
+        ctx.clearRect(0, 0, width, height);
 
         var text = this._label + " ";
         var textWidth = ctx.measureText(text).width;
@@ -164,6 +162,7 @@ class SliderWidget extends CanvasWidget {
         var handleHeight = height * HANDLE_HEIGHT_AMT;
         var halfHeight = height / 2;
 
+        var backgroundColor = Color.parse(style.backgroundColor).toCss();
         var foregroundColor = Color.parse(style.color).toCss();
 
         ctx.clearRect(0, 0, width, height);

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -129,11 +129,11 @@ class SliderWidget extends CanvasWidget {
 
         ctx.clearRect(0, 0, width, height);
 
+        ctx.font = style.font;
+        style.fontSize = Math.round(height * LABEL_HEIGHT_AMT) + "px";
         var text = this._label + " ";
         var textWidth = ctx.measureText(text).width;
-        style.fontSize = Math.round(height * LABEL_HEIGHT_AMT) + "px";
         ctx.fillStyle = foregroundColor;
-        ctx.font = style.font;
         ctx.textBaseline = "middle";
         ctx.fillText(text, labelWidth - textWidth, halfHeight);
 
@@ -171,11 +171,11 @@ class SliderWidget extends CanvasWidget {
         // end.
         var totalRange = this._maxValue - this._minValue;
         var totalSlide = sliderWidth - handleWidth;
-        var x = labelWidth + (sliderWidth/2) +
-            ((this._value - this._minValue) / totalRange * totalSlide);
+        var slideRatio = (this._value - this._minValue) / totalRange;
+        var x = labelWidth + (handleWidth / 2) + (slideRatio * totalSlide);
 
         SliderWidget._roundRectPath(ctx,
-            x - (handleWidth/2), halfHeight - (handleHeight/2),
+            x - (handleWidth / 2), halfHeight - (handleHeight / 2),
             handleWidth, handleHeight,
             handleWidth * 0.25);
         ctx.fillStyle = backgroundColor;
@@ -185,6 +185,31 @@ class SliderWidget extends CanvasWidget {
         ctx.lineCap = "round";
         ctx.lineJoin = "round";
         ctx.stroke();
+
+        ctx.font = style.font;
+        var fontSize = Math.round(handleHeight * 0.4);
+        var boxHeight = fontSize * 1.5;
+        style.fontSize = fontSize + "px";
+        var text = " " + this._value + " ";
+        var textWidth = ctx.measureText(text).width;
+        var textX = (slideRatio < 0.5)
+            ? (x + handleWidth)
+            : (x - handleWidth - textWidth);
+        SliderWidget._roundRectPath(ctx,
+            x + handleWidth, halfHeight - (boxHeight / 2),
+            textWidth, boxHeight,
+            handleWidth * 0.25);
+        ctx.fillStyle = backgroundColor;
+        ctx.fill();
+        ctx.strokeStyle = foregroundColor;
+        ctx.lineWidth = this.thinLineWidth;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.stroke();
+
+        ctx.fillStyle = foregroundColor;
+        ctx.textBaseline = "middle";
+        ctx.fillText(text, x + handleWidth, halfHeight);
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -60,10 +60,12 @@ class SliderWidget extends CanvasWidget {
      */
     _inputSetup() {
         var outerThis = this;
-        var target = this._divNode;  // Element that gets all the events.
+        var target = this._divNode;  // Wrapper element for this instance.
         var view = target.ownerDocument.defaultView;  // The window.
+        var pendingDelta = 0;  // Scroll delta not yet used.
 
         target.addEventListener("mousedown", mousedown);
+        target.addEventListener("wheel", wheel);
 
         // If and when `target.setCapture(true)` (or something like it) becomes
         // standardly available, then that should be used, at which point the
@@ -89,6 +91,30 @@ class SliderWidget extends CanvasWidget {
             var targetCoords = target.getBoundingClientRect();
             var x = event.clientX - targetCoords.left;
             outerThis.value = outerThis._xToValue(x);
+        }
+
+        function wheel(event) {
+            event.stopPropagation();
+            event.preventDefault();
+
+            // We treat both up and left as decrement, and down and right as
+            // increment. In addition, we scale the delta if given lines or
+            // pages.
+            var delta = -(event.deltaX + event.deltaY);
+            switch (event.deltaMode) {
+                case WheelEvent.DOM_DELTA_LINE: { delta *= 10;  break; }
+                case WheelEvent.DOM_DELTA_PAGE: { delta *= 100; break; }
+            }
+
+            // We only increment by "lines." However, if we're given pixels, we
+            // have to build up a line across a series of events. Thus, we
+            // accumulate into `pendingDelta` and take action when it's over
+            // the line threshold.
+            pendingDelta += delta;
+            if (Math.abs(pendingDelta) > 10) {
+                outerThis.value += (pendingDelta / 10) * outerThis._increment;
+                pendingDelta %= 10;
+            }
         }
     }
 

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -6,6 +6,8 @@
 
 "use strict";
 
+define(["./CanvasWidget", "./Color"], function(CanvasWidget, Color) {
+
 /** Label font size as a fraction of canvas height. */
 var LABEL_HEIGHT_AMT = 0.5;
 
@@ -113,7 +115,7 @@ class SliderWidget extends CanvasWidget {
      * Renders the background canvas.
      */
     renderBackground() {
-        var canvas = this.background;
+        var canvas = this.foreground;
         var style = this.cloneComputedStyle();
         var ctx = canvas.getContext("2d");
         var width = canvas.width;
@@ -202,3 +204,6 @@ class SliderWidget extends CanvasWidget {
         ctx.quadraticCurveTo(x, y, x, y + radius);
     }
 }
+
+return SliderWidget;
+});

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -8,9 +8,6 @@
 
 define(["./CanvasWidget", "./Color"], function(CanvasWidget, Color) {
 
-/** Label font size as a fraction of canvas height. */
-var LABEL_HEIGHT_AMT = 0.6;
-
 /** Fraction of width to use for the label. */
 var LABEL_WIDTH_AMT = 0.25;
 
@@ -163,7 +160,7 @@ class SliderWidget extends CanvasWidget {
         ctx.clearRect(0, 0, width, height);
 
         ctx.font = style.font;
-        style.fontSize = Math.round(height * LABEL_HEIGHT_AMT) + "px";
+        style.fontSize = this.fontSizePx;
         var text = this._label + " ";
         var textWidth = ctx.measureText(text).width;
         ctx.fillStyle = foregroundColor;

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -45,7 +45,7 @@ class SliderWidget extends CanvasWidget {
         this._maxValue = 10;
 
         /** Value increment. */
-        this._increment = 1;
+        this._increment = 0.1;
 
         /** Current value. */
         this._value = 0;
@@ -103,7 +103,7 @@ class SliderWidget extends CanvasWidget {
      * Clamps and quantizes the given (would-be) value.
      */
     _clampAndQuantize(value) {
-        value = Math.round(value * this._increment) / this._increment;
+        value = Math.round(value / this._increment) * this._increment;
         value = Math.min(value, this._maxValue);
         value = Math.max(value, this._minValue);
         return value;

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -195,16 +195,16 @@ class SliderWidget extends CanvasWidget {
         ctx.stroke();
 
         ctx.font = style.font;
-        var fontSize = Math.round(handleHeight * 0.4);
-        var boxHeight = fontSize * 1.5;
+        var fontSize = Math.round(handleHeight * 0.25);
+        var boxHeight = fontSize * 3;
         style.fontSize = fontSize + "px";
         var text = " " + this._value + " ";
         var textWidth = ctx.measureText(text).width;
-        var textX = (x < ((this._xMin + this._xMax) / 2))
+        var textX = (this._sliderSide === "left")
             ? (x + handleWidth)
             : (x - handleWidth - textWidth);
         SliderWidget._roundRectPath(ctx,
-            x + handleWidth, halfHeight - (boxHeight / 2),
+            textX, halfHeight - (boxHeight / 2),
             textWidth, boxHeight,
             handleWidth * 0.25);
         ctx.fillStyle = backgroundColor;
@@ -217,7 +217,7 @@ class SliderWidget extends CanvasWidget {
 
         ctx.fillStyle = foregroundColor;
         ctx.textBaseline = "middle";
-        ctx.fillText(text, x + handleWidth, halfHeight);
+        ctx.fillText(text, textX, halfHeight);
     }
 
     /** The width of the left-hand label. */
@@ -258,6 +258,14 @@ class SliderWidget extends CanvasWidget {
         var totalSlide = this._xMax - this._xMin;
         var valueRatio = (this._value - this._minValue) / totalRange;
         return this._xMin + (valueRatio * totalSlide);
+    }
+
+    /**
+     * Which side the slider is on. Either "left" or "right".
+     */
+    get _sliderSide() {
+        return (this._value < ((this._minValue + this._maxValue) / 2))
+            ? "left" : "right";
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -115,7 +115,7 @@ class SliderWidget extends CanvasWidget {
      * Renders the background canvas.
      */
     renderBackground() {
-        var canvas = this.foreground;
+        var canvas = this.background;
         var style = this.cloneComputedStyle();
         var ctx = canvas.getContext("2d");
         var width = canvas.width;
@@ -151,7 +151,7 @@ class SliderWidget extends CanvasWidget {
      * Renders the control position into the foreground canvas.
      */
     render() {
-        var canvas = this.background;
+        var canvas = this.foreground;
         var style = this.cloneComputedStyle();
         var ctx = canvas.getContext("2d");
         var width = canvas.width;

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -47,6 +47,9 @@ class SliderWidget extends CanvasWidget {
         /** Value increment. */
         this._increment = 0.1;
 
+        /** Value precision in decimal places. */
+        this._precision = 1;
+
         /** Current value. */
         this._value = 0;
 
@@ -77,8 +80,8 @@ class SliderWidget extends CanvasWidget {
      */
     set minValue(value) {
         this._minValue = value;
-        this.renderBackground();
         this.value = this.value;  // Clamp if necessary.
+        this.render();
     }
 
     /**
@@ -86,8 +89,8 @@ class SliderWidget extends CanvasWidget {
      */
     set maxValue(value) {
         this._maxValue = value;
-        this.renderBackground();
         this.value = this.value;  // Clamp if necessary.
+        this.render();
     }
 
     /**
@@ -95,8 +98,15 @@ class SliderWidget extends CanvasWidget {
      */
     set increment(value) {
         this._increment = value;
-        this.renderBackground();
         this.value = this.value;  // Clamp if necessary.
+    }
+
+    /**
+     * Sets the precision, in decimal places.
+     */
+    set precision(value) {
+        this._precision = value;
+        this.render();
     }
 
     /**
@@ -127,6 +137,13 @@ class SliderWidget extends CanvasWidget {
      */
     get value() {
         return this._value;
+    }
+
+    /**
+     * Gets the current value as formatted text.
+     */
+    get valueText() {
+        return this._value.toFixed(this._precision);
     }
 
     /**
@@ -181,6 +198,10 @@ class SliderWidget extends CanvasWidget {
 
         ctx.clearRect(0, 0, width, height);
 
+        if (this._value === undefined) {
+            return;
+        }
+
         var x = this._sliderX;
         SliderWidget._roundRectPath(ctx,
             x - (handleWidth / 2), halfHeight - (handleHeight / 2),
@@ -193,16 +214,20 @@ class SliderWidget extends CanvasWidget {
         ctx.lineCap = "round";
         ctx.lineJoin = "round";
         ctx.stroke();
+        ctx.beginPath();
+        ctx.moveTo(x, halfHeight - (handleHeight / 2));
+        ctx.lineTo(x, halfHeight + (handleHeight / 2));
+        ctx.stroke();
 
         ctx.font = style.font;
         var fontSize = Math.round(handleHeight * 0.25);
         var boxHeight = fontSize * 3;
         style.fontSize = fontSize + "px";
-        var text = " " + this._value + " ";
+        var text = " " + this.valueText + " ";
         var textWidth = ctx.measureText(text).width;
         var textX = (this._sliderSide === "left")
-            ? (x + handleWidth)
-            : (x - handleWidth - textWidth);
+            ? (x + (handleWidth * 2))
+            : (x - (handleWidth * 2) - textWidth);
         SliderWidget._roundRectPath(ctx,
             textX, halfHeight - (boxHeight / 2),
             textWidth, boxHeight,

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -22,7 +22,9 @@ var HANDLE_HEIGHT_AMT = 0.95;
 
 
 /**
- * Slider control widget, with settable label, range, increment, and targeting.
+ * Slider control widget, with settable label, range, increment, and display
+ * precision. Use the `target` and `targetProperty` properties to give it an
+ * object property to control.
  */
 class SliderWidget extends CanvasWidget {
     /**
@@ -49,6 +51,12 @@ class SliderWidget extends CanvasWidget {
 
         /** Current value. */
         this._value = 0;
+
+        /** Target object to control. */
+        this._target = undefined;
+
+        /** Name of the property of the target to control. */
+        this._targetProperty = undefined;
 
         this.renderBackground();
         this.render();
@@ -161,6 +169,25 @@ class SliderWidget extends CanvasWidget {
     }
 
     /**
+     * Sets the target to control. The existing value in the target is pulled
+     * in as the value of this instance.
+     */
+    set target(t) {
+        this._target = t;
+        if (t && this._targetProperty) {
+            this.value = t[this._targetProperty];
+        }
+    }
+
+    /**
+     * Sets the target property to control (by name).
+     */
+    set targetProperty(name) {
+        this._targetProperty = name;
+        this._target = this._target; // Grab the value if possible.
+    }
+
+    /**
      * Clamps and quantizes the given (would-be) value.
      */
     _clampAndQuantize(value) {
@@ -180,6 +207,10 @@ class SliderWidget extends CanvasWidget {
         if (value !== this._value) {
             this._value = value;
             this.render();
+
+            if (this._target && this._targetProperty) {
+                this._target[this._targetProperty] = value;
+            }
         }
     }
 

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -314,15 +314,17 @@ class SliderWidget extends CanvasWidget {
     /** The element-relative x value corresponding to `minValue`. */
     get _xMin() {
         // Note: The actual "throw" of slider is cut off by half a slider width
-        // on either end.
-        return this._labelWidth + (this._handleWidth / 2);
+        // on either end, plus a little bit extra to account for the thickness
+        // of the stroke around the handle.
+        return this._labelWidth + (this._handleWidth / 2) + this.thinLineWidth;
     }
 
     /** The element-relative x value corresponding to `maxValue`. */
     get _xMax() {
         // Note: The actual "throw" of slider is cut off by half a slider width
         // on either end.
-        return this._labelWidth + this._sliderWidth - (this._handleWidth / 2);
+        return this._labelWidth + this._sliderWidth - (this._handleWidth / 2)
+            - this.thinLineWidth;
     }
 
     /**

--- a/lib/SliderWidget.js
+++ b/lib/SliderWidget.js
@@ -9,7 +9,7 @@
 define(["./CanvasWidget", "./Color"], function(CanvasWidget, Color) {
 
 /** Label font size as a fraction of canvas height. */
-var LABEL_HEIGHT_AMT = 0.5;
+var LABEL_HEIGHT_AMT = 0.6;
 
 /** Fraction of width to use for the label. */
 var LABEL_WIDTH_AMT = 0.25;
@@ -18,10 +18,10 @@ var LABEL_WIDTH_AMT = 0.25;
 var SLIDER_WIDTH_AMT = 0.75;
 
 /** Fraction of width to use for the handle. */
-var HANDLE_WIDTH_AMT = 0.01;
+var HANDLE_WIDTH_AMT = 0.025;
 
 /** Fraction of heightto use for the handle. */
-var HANDLE_HEIGHT_AMT = 0.9;
+var HANDLE_HEIGHT_AMT = 0.95;
 
 
 /**
@@ -174,12 +174,17 @@ class SliderWidget extends CanvasWidget {
         var x = labelWidth + (sliderWidth/2) +
             ((this._value - this._minValue) / totalRange * totalSlide);
 
-        ctx.fillStyle = foregroundColor;
         SliderWidget._roundRectPath(ctx,
             x - (handleWidth/2), halfHeight - (handleHeight/2),
             handleWidth, handleHeight,
             handleWidth * 0.25);
+        ctx.fillStyle = backgroundColor;
         ctx.fill();
+        ctx.strokeStyle = foregroundColor;
+        ctx.lineWidth = this.thinLineWidth;
+        ctx.lineCap = "round";
+        ctx.lineJoin = "round";
+        ctx.stroke();
     }
 
     /**

--- a/pink-noise-explorer/Piece.js
+++ b/pink-noise-explorer/Piece.js
@@ -72,6 +72,13 @@ class Piece {
     }
 
     /**
+     * Gets the output amplitude.
+     */
+    get amp() {
+        return this._amp;
+    }
+
+    /**
      * Sets the alpha.
      */
     set alpha(value) {
@@ -87,11 +94,25 @@ class Piece {
     }
 
     /**
+     * Gets the alpha.
+     */
+    get alpha() {
+        return this._alpha;
+    }
+
+    /**
      * Sets the count of poles.
      */
     set poles(value) {
         this._poles = value;
         this._calcFilter();
+    }
+
+    /**
+     * Gets the count of poles.
+     */
+    get poles() {
+        return this._poles;
     }
 
     /**

--- a/pink-noise-explorer/index.css
+++ b/pink-noise-explorer/index.css
@@ -65,7 +65,7 @@ button {
     width: 100%;
 }
 
-#controlTable tr:nth-child(even) td {
+#controlTable td {
     padding-bottom: 1em;
 }
 
@@ -86,4 +86,17 @@ button {
 
 #controlTable td:first-child + td + td {
     text-align: right;
+}
+
+.sliderCell {
+    width: 100%;
+    height: 28pt;
+}
+
+.slider {
+    width: 100%;
+    height: 28pt;
+    background-color: #eeeeee;
+    color: black;
+    font-size: 15pt;
 }

--- a/pink-noise-explorer/index.html
+++ b/pink-noise-explorer/index.html
@@ -30,20 +30,14 @@
     <table id="controlTable">
         <tr>
             <td>Low <i>&alpha;</i></td>
-            <td>
-                <input id="alpha" type="range" value="1" min="0" max="2" step="0.02">
-            </td>
+            <td id="alpha" class="sliderCell"></td>
             <td>High <i>&alpha;</i></td>
         </tr>
-        <tr><td/><td id="alphaText">1</td><td/></tr>
         <tr>
             <td>Low Amplitude</td>
-            <td>
-                <input id="amp" type="range" value="0.5" min="0" max="1" step="0.02">
-            </td>
+            <td id="amp" class="sliderCell"></td>
             <td>High Amplitude</td>
         </tr>
-        <tr><td/><td id="ampText">0.5</td><td/></tr>
     </table>
 
     <h3>What is this?</h3>

--- a/pink-noise-explorer/index.js
+++ b/pink-noise-explorer/index.js
@@ -13,8 +13,9 @@
 });
 
 requirejs(
-["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope"],
-function(Piece, Harmonics, MusicControl, Oscilloscope) {
+["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope",
+    "lib/SliderWidget"],
+function(Piece, Harmonics, MusicControl, Oscilloscope, SliderWidget) {
 
 // The overall audio context instance. Unfortunately, the name
 // `AudioContext` isn't fully standardized and is prefixed in some
@@ -27,21 +28,26 @@ var mc = new MusicControl(audioCtx, gen);
 mc.oscilloscope = new Oscilloscope(document.querySelector("#oscCell"));
 mc.harmonics = new Harmonics(document.querySelector("#harmCell"));
 
-var alphaText = document.querySelector("#alphaText");
-var ampText = document.querySelector("#ampText");
-
 document.querySelector("#playPause").onclick = function() {
     mc.playPause();
 };
 
-document.querySelector("#alpha").oninput = function() {
-    gen.alpha = parseFloat(this.value);
-    alphaText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#alpha"), {
+    minValue:       0,
+    maxValue:       2,
+    increment:      0.02,
+    precision:      2,
+    target:         gen,
+    targetProperty: "alpha"
+});
 
-document.querySelector("#amp").oninput = function() {
-    gen.amp = parseFloat(this.value);
-    ampText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#amp"), {
+    minValue:       0,
+    maxValue:       1,
+    increment:      0.02,
+    precision:      2,
+    target:         gen,
+    targetProperty: "amp"
+});
 
 });

--- a/triangle-wave-explorer/Piece.js
+++ b/triangle-wave-explorer/Piece.js
@@ -132,11 +132,25 @@ class Piece {
     }
 
     /**
-     * Sets note frequency.
+     * Gets the output amplitude.
+     */
+    get amp() {
+        return this._amp;
+    }
+
+    /**
+     * Sets the note frequency.
      */
     set freq(freq) {
         this._freq = freq;
         this._needCalc = true;
+    }
+
+    /**
+     * Gets the note frequency.
+     */
+    get freq() {
+        return this._freq;
     }
 
     /**
@@ -148,6 +162,13 @@ class Piece {
     }
 
     /**
+     * Gets the upward bias.
+     */
+    get upBias() {
+        return this._upBias;
+    }
+
+    /**
      * Sets the positive bias.
      */
     set posBias(value) {
@@ -156,11 +177,25 @@ class Piece {
     }
 
     /**
+     * Gets the upward bias.
+     */
+    get posBias() {
+        return this._posBias;
+    }
+
+    /**
      * Sets the amping bias.
      */
     set ampBias(value) {
         this._ampBias = value;
         this._needCalc = true;
+    }
+
+    /**
+     * Gets the amping bias.
+     */
+    get ampBias() {
+        return this._ampBias;
     }
 
     /**

--- a/triangle-wave-explorer/Piece.js
+++ b/triangle-wave-explorer/Piece.js
@@ -65,7 +65,7 @@ class Piece {
         this._amp = 0.75;
 
         /** Upward bias. */
-        this._upBias = 0.005;
+        this._upBias = 0.0;
 
         /** Positive bias. */
         this._posBias = 0.0;

--- a/triangle-wave-explorer/index.css
+++ b/triangle-wave-explorer/index.css
@@ -65,7 +65,7 @@ button {
     width: 100%;
 }
 
-#controlTable tr:nth-child(even) td {
+#controlTable td {
     padding-bottom: 1em;
 }
 
@@ -86,4 +86,18 @@ button {
 
 #controlTable td:first-child + td + td {
     text-align: right;
+}
+
+
+.sliderCell {
+    width: 100%;
+    height: 28pt;
+}
+
+.slider {
+    width: 100%;
+    height: 28pt;
+    background-color: #eeeeee;
+    color: black;
+    font-size: 15pt;
 }

--- a/triangle-wave-explorer/index.html
+++ b/triangle-wave-explorer/index.html
@@ -30,44 +30,29 @@
     <table id="controlTable">
         <tr>
             <td>Downward Bias</td>
-            <td>
-                <input id="upBias" type="range" value="0" min="-1" max="1" step="0.005">
-            </td>
+            <td id="upBias" class="sliderCell"></td>
             <td>Upward Bias</td>
         </tr>
-        <tr><td/><td id="upBiasText">0</td><td/></tr>
         <tr>
             <td>Negative Bias</td>
-            <td>
-                <input id="posBias" type="range" value="0" min="-1" max="1" step="0.005">
-            </td>
+            <td id="posBias" class="sliderCell"></td>
             <td>Positive Bias</td>
         </tr>
-        <tr><td/><td id="posBiasText">0</td><td/></tr>
         <tr>
             <td>De&auml;mping Bias</td>
-            <td>
-                <input id="ampBias" type="range" value="0" min="-1" max="1" step="0.005">
-            </td>
+            <td id="ampBias" class="sliderCell"></td>
             <td>Amping Bias</td>
         </tr>
-        <tr><td/><td id="ampBiasText">0</td><td/></tr>
         <tr>
             <td>Low Pitch</td>
-            <td>
-                <input id="freq" type="range" value="440" min="20" max="8000" step="1">
-            </td>
+            <td id="freq" class="sliderCell"></td>
             <td>High Pitch</td>
         </tr>
-        <tr><td/><td id="freqText">440</td><td/></tr>
         <tr>
             <td>Low Amplitude</td>
-            <td>
-                <input id="amp" type="range" value="0.75" min="0" max="1" step="0.01">
-            </td>
+            <td id="amp" class="sliderCell"></td>
             <td>High Amplitude</td>
         </tr>
-        <tr><td/><td id="ampText">0.75</td><td/></tr>
     </table>
 
     <h3>What is this?</h3>

--- a/triangle-wave-explorer/index.js
+++ b/triangle-wave-explorer/index.js
@@ -13,8 +13,9 @@
 });
 
 requirejs(
-["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope"],
-function(Piece, Harmonics, MusicControl, Oscilloscope) {
+["Piece", "lib/Harmonics", "lib/MusicControl", "lib/Oscilloscope",
+    "lib/SliderWidget"],
+function(Piece, Harmonics, MusicControl, Oscilloscope, SliderWidget) {
 
 // The overall audio context instance. Unfortunately, the name
 // `AudioContext` isn't fully standardized and is prefixed in some
@@ -27,39 +28,54 @@ var mc = new MusicControl(audioCtx, gen);
 mc.oscilloscope = new Oscilloscope(document.querySelector("#oscCell"));
 mc.harmonics = new Harmonics(document.querySelector("#harmCell"));
 
-var upBiasText = document.querySelector("#upBiasText");
-var posBiasText = document.querySelector("#posBiasText");
-var ampBiasText = document.querySelector("#ampBiasText");
-var freqText = document.querySelector("#freqText");
-var ampText = document.querySelector("#ampText");
-
 document.querySelector("#playPause").onclick = function() {
     mc.playPause();
 };
 
-document.querySelector("#upBias").oninput = function() {
-    gen.upBias = parseFloat(this.value);
-    upBiasText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#upBias"), {
+    minValue:       -1,
+    maxValue:       1,
+    increment:      0.005,
+    precision:      3,
+    target:         gen,
+    targetProperty: "upBias"
+});
 
-document.querySelector("#posBias").oninput = function() {
-    gen.posBias = parseFloat(this.value);
-    posBiasText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#posBias"), {
+    minValue:       -1,
+    maxValue:       1,
+    increment:      0.005,
+    precision:      3,
+    target:         gen,
+    targetProperty: "posBias"
+});
 
-document.querySelector("#ampBias").oninput = function() {
-    gen.ampBias = parseFloat(this.value);
-    ampBiasText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#ampBias"), {
+    minValue:       -1,
+    maxValue:       1,
+    increment:      0.005,
+    precision:      3,
+    target:         gen,
+    targetProperty: "ampBias"
+});
 
-document.querySelector("#freq").oninput = function() {
-    gen.freq = parseFloat(this.value);
-    freqText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#freq"), {
+    minValue:       20,
+    maxValue:       8000,
+    increment:      1,
+    precision:      0,
+    target:         gen,
+    targetProperty: "freq"
+});
 
-document.querySelector("#amp").oninput = function() {
-    gen.amp = parseFloat(this.value);
-    ampText.textContent = this.value;
-};
+new SliderWidget(document.querySelector("#amp"), {
+    minValue:       0,
+    maxValue:       1,
+    increment:      0.01,
+    precision:      2,
+    target:         gen,
+    targetProperty: "amp"
+});
+
 
 });


### PR DESCRIPTION
This PR implements and uses a bespoke slider widget instead of the builtin range input. Why? To have something that looks nicer, responds to wheel events sensibly, and is easier to set up. Also, as a way for me to learn the basics of web UI work, instead of figuring it out on something more complicated.

I did my best to stick with widely-implemented web features (HTML, the DOM, JavaScript, etc.). Nonetheless, this seems to have run across some kind of incompatibility with or bug in Safari (unclear as yet). Safari _already_ wasn't working, so at least it's status quo on that front. Nonetheless, it'd be nice to figure out what's up with it.
